### PR TITLE
Update for Chrome 148 compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Image Details Inspector",
-  "version": "1.4",
+  "version": "1.4.1",
   "description": "Inspect image dimensions and aspect ratios with an interactive overlay",
   "action": {
     "default_popup": "popup.html",

--- a/popup.js
+++ b/popup.js
@@ -152,15 +152,15 @@ document.addEventListener('DOMContentLoaded', function () {
             // Always disable the current mode before enabling a new one.
             await executeScriptSafe({
                 target: { tabId: activeTabId },
-                function: disableInspectorMode,
+                func: disableInspectorMode,
             });
 
             if (mode === 'inspector') {
                 await executeScriptSafe({
                     target: { tabId: activeTabId },
-                    function: () => {
+                    func: () => {
                         window.imageDetailsOverlayApiOnly = true;
-                    }
+                    },
                 });
 
                 await executeScriptSafe({


### PR DESCRIPTION
Modify `popup.js` to use `func` instead of `function` for `chrome.scripting.executeScript` calls, ensuring compatibility with Chrome 148. Update the version in `manifest.json` to reflect this change.